### PR TITLE
refactor: refactor bad smell ProtectedMemberInFinalClass

### DIFF
--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedRepositoryListener.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedRepositoryListener.java
@@ -111,7 +111,7 @@ public final class ChainedRepositoryListener extends AbstractRepositoryListener 
     }
 
     @SuppressWarnings("EmptyMethod")
-    protected void handleError(RepositoryEvent event, RepositoryListener listener, RuntimeException error) {
+void handleError(RepositoryEvent event, RepositoryListener listener, RuntimeException error) {
         // default just swallows errors
     }
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedRepositoryListener.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedRepositoryListener.java
@@ -111,7 +111,7 @@ public final class ChainedRepositoryListener extends AbstractRepositoryListener 
     }
 
     @SuppressWarnings("EmptyMethod")
-void handleError(RepositoryEvent event, RepositoryListener listener, RuntimeException error) {
+    void handleError(RepositoryEvent event, RepositoryListener listener, RuntimeException error) {
         // default just swallows errors
     }
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedTransferListener.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedTransferListener.java
@@ -112,7 +112,7 @@ public final class ChainedTransferListener extends AbstractTransferListener {
     }
 
     @SuppressWarnings("EmptyMethod")
-    protected void handleError(TransferEvent event, TransferListener listener, RuntimeException error) {
+void handleError(TransferEvent event, TransferListener listener, RuntimeException error) {
         // default just swallows errors
     }
 

--- a/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedTransferListener.java
+++ b/maven-resolver-util/src/main/java/org/eclipse/aether/util/listener/ChainedTransferListener.java
@@ -112,7 +112,7 @@ public final class ChainedTransferListener extends AbstractTransferListener {
     }
 
     @SuppressWarnings("EmptyMethod")
-void handleError(TransferEvent event, TransferListener listener, RuntimeException error) {
+    void handleError(TransferEvent event, TransferListener listener, RuntimeException error) {
         // default just swallows errors
     }
 


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## ProtectedMemberInFinalClass
Since final classes cannot be inherited, marking a member as protected may be confusing. It is better to declare such members as private or package-visible instead.
<!-- fingerprint:Qodana-maven-resolver-ProtectedMemberInFinalClass-1010f0f7ce3381d99bc068f71606e967e61ae3c9-sl:132-el:0-sc:5-ec:0-co:4327-cl:9 -->
<!-- fingerprint:Qodana-maven-resolver-ProtectedMemberInFinalClass-1010f0f7ce3381d99bc068f71606e967e61ae3c9-sl:131-el:0-sc:5-ec:0-co:4275-cl:9 -->
# Repairing Code Style Issues
* ProtectedMemberInFinalClass (2)
